### PR TITLE
fix secondary button that appears transparent

### DIFF
--- a/themes/new_dark.json
+++ b/themes/new_dark.json
@@ -53,6 +53,7 @@
 
     "button.background": "#3574f0",
     "button.foreground": "#ffffff",
+    "button.border": "#4f5156",
     "button.hoverBackground": "#538af6",
     "button.secondaryBackground": "#2b2d30",
     "button.secondaryForeground": "#dfe1e5",


### PR DESCRIPTION
before:

![제목 없음](https://github.com/eenaree/new-dark-theme/assets/37580351/fca9bc6b-e64d-437e-825b-f4f18f3e5985)

after:

![스크린샷 2023-09-18 142932](https://github.com/eenaree/new-dark-theme/assets/37580351/8d7b0cbd-60e0-4c21-b943-832a9861be38)

While border has been added to primary buttons, secondary buttons are no longer rendered as if they were transparent.