### PR TITLE
Fix the color of objects accessed by dot notation when semantic highlighting is not applied

### DIFF
--- a/themes/new_darcula.json
+++ b/themes/new_darcula.json
@@ -391,6 +391,7 @@
       "scope": [
         "entity.name.type.module",
         "entity.name.constant",
+        "variable.other.object",
         "variable.other.property",
         "variable.other.object.property",
         "variable.other.constant.property",
@@ -481,7 +482,6 @@
         "meta.tag.attributes",
         "meta.at-rule.for keyword.control.operator",
         "variable.interpolation",
-        "variable.other.object",
         "entity.name.type",
         "entity.name.function.tagged-template",
         "constant.language.import-export-all",

--- a/themes/new_dark.json
+++ b/themes/new_dark.json
@@ -394,6 +394,7 @@
       "scope": [
         "entity.name.type.module",
         "entity.name.constant",
+        "variable.other.object",
         "variable.other.property",
         "variable.other.object.property",
         "variable.other.constant.property",
@@ -483,7 +484,6 @@
       "scope": [
         "meta.tag.attributes",
         "meta.at-rule.for keyword.control.operator",
-        "variable.other.object",
         "variable.interpolation",
         "entity.name.type",
         "entity.name.function.tagged-template",

--- a/themes/new_light.json
+++ b/themes/new_light.json
@@ -399,6 +399,7 @@
       "scope": [
         "entity.name.type.module",
         "entity.name.constant",
+        "variable.other.object",
         "variable.other.property",
         "variable.other.object.property",
         "variable.other.constant.property",
@@ -485,7 +486,6 @@
         "meta.at-rule.for keyword.control.operator",
         "meta.tag.metadata.doctype.html entity.name.tag",
         "variable.interpolation",
-        "variable.other.object",
         "variable.other.jsdoc",
         "entity.name.type",
         "entity.name.function.tagged-template",

--- a/themes/new_light_with_darkHeader.json
+++ b/themes/new_light_with_darkHeader.json
@@ -403,6 +403,7 @@
       "scope": [
         "entity.name.type.module",
         "entity.name.constant",
+        "variable.other.object",
         "variable.other.property",
         "variable.other.object.property",
         "variable.other.constant.property",
@@ -489,7 +490,6 @@
         "meta.at-rule.for keyword.control.operator",
         "meta.tag.metadata.doctype.html entity.name.tag",
         "variable.interpolation",
-        "variable.other.object",
         "variable.other.jsdoc",
         "entity.name.type",
         "entity.name.function.tagged-template",


### PR DESCRIPTION
closes #6 

This is just a workaround for when semantic highlighting is not applied.
Also, WebStorm and VSCode do not apply colors to variables in the same way, so I still use uniform colors for variables.